### PR TITLE
fix: resolve Prisma P1012 error by moving database URL to prisma.conf…

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -2,4 +2,9 @@ import { defineConfig } from "@prisma/config";
 
 export default defineConfig({
   schema: "./prisma",
+  datasources: {
+    db: {
+      url: process.env.DATABASE_URL,
+    },
+  },
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,5 +9,4 @@ generator json {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }


### PR DESCRIPTION
…ig.ts

Move datasource URL configuration from schema.prisma to prisma.config.ts to fix P1012 error after Prisma update. This follows the new Prisma v6+ requirement where connection URLs should be in configuration files.

Fixes #6