### PR TITLE
fix: resolve P1012 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ COPY --from=prerelease  /usr/src/app/.next/standalone ./
 COPY --from=prerelease  /usr/src/app/.next/static ./.next/static
 COPY --from=prerelease  /usr/src/app/prisma ./prisma
 
+RUN bun add prisma@$(bun -e "const p = require('./package.json'); console.log(p.devDependencies.prisma)")
+
 # Create startup script to run migrations then start the app
 RUN echo '#!/bin/sh\n\
 echo "Running database migrations..."\n\

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -2,9 +2,4 @@ import { defineConfig } from "@prisma/config";
 
 export default defineConfig({
   schema: "./prisma",
-  datasources: {
-    db: {
-      url: process.env.DATABASE_URL,
-    },
-  },
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,4 +9,5 @@ generator json {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }


### PR DESCRIPTION
Version of prisma in the project : 6.15.0
Resolved version of prisma cli on app boot : 7.12

The issue is due to the build of Next.js removing all packages not referenced in the production code of the application. 
And indeed, prisma-cli is never mentionned anywhere except in the Dockerfile entrypoint script.

💡 Maybe we should think about moving the prisma migration execution to a pre-deploy job.
✅ But to quick fix that, I added a step in the dockerfile to pre-install prisma-cli and not let bunx get the latest version by itself.